### PR TITLE
Add log time to all frogs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ pub struct DeadFrog {
     name: Option<String>,
     sex: Option<Sex>,
     location: usize,
+    time: DateTime<Local>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
@@ -227,6 +228,7 @@ impl State {
             name,
             sex: None,
             location,
+            time: Local::now(),
         });
         dialoge.update(State::WalkStarted { walk }).await?;
         found_something(bot, dialoge).await?;


### PR DESCRIPTION
Fixes #33.

* **Add log time to frogs**
* **Add log time to dead frogs :( as well**
